### PR TITLE
Add OpenAI SDK provider support and fix Claude usage compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ---
-
 <img width="400" height="200" alt="33f1d0d49cce103272da3821f66a2820" src="https://github.com/user-attachments/assets/fd909546-1544-4b7d-a7c1-67244d729e4f" />
 
 本项目由 [code0.ai](https://code0.ai?source=claudeworkerproxy) 赞助 —— 一站接入 gpt-image / Gemini / Claude 等主流 AI 模型，稳定不掉线，按量计费即充即用，专为 AI 创作者打造。注册后联系客服可免费领取测试额度，支持企业对接及开票。
@@ -7,7 +6,6 @@
 <img width="400" height="200" alt="4ca65f573c3d7b3dec0cd829d86262f6" src="https://github.com/user-attachments/assets/9fcffadc-2b95-411d-b778-bf33809f7ef7" />
 
 感谢 [Claude API](https://www.claudeapi.com?source=claudeworkerproxy) 赞助本项目！Claude API 是专注 Claude 模型的官方渠道 API 服务商，基于 Anthropic 官方 Key 与 AWS Bedrock 官方渠道，提供稳定的 Claude Code 与 Agent 应用接入体验，支持 Claude 全系列模型，保留 Tool Use、长上下文等官方能力。服务非逆向、非降智，适合 Claude Code 深度用户、Agent 工程师与企业技术团队使用。通过[专属链接](https://www.claudeapi.com?source=claudeworkerproxy)注册后联系客服，可领取免费测试额度，并支持开票和团队对接。
-
 ---
 
 把各家（Gemini，OpenAI）的模型 API 转换成 Claude 格式提供服务
@@ -48,9 +46,39 @@ curl -X POST https://claude-worker-proxy.xxxx.workers.dev/gemini/https://generat
 ### 参数说明
 
 - URL 格式：`{worker_url}/{type}/{provider_url_with_version}/v1/messages`
-- `type`: 目标厂商类型，目前支持 `gemini`, `openai`
+- `type`: 目标厂商类型，目前支持 `gemini`, `openai`, `openai-responses`
 - `provider_url_with_version`: 目标厂商 API 基础地址
 - `x-api-key`: 目标厂商的 API Key
+
+OpenAI Chat Completions 示例：
+
+```bash
+curl -X POST https://claude.llmapp.org/openai/https://api.openai.com/v1/v1/messages \
+  -H "x-api-key: YOUR_OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "max_tokens": 128,
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+
+OpenAI Responses API 示例：
+
+```bash
+curl -X POST https://claude.llmapp.org/openai-responses/https://api.openai.com/v1/v1/messages \
+  -H "x-api-key: YOUR_OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1-mini",
+    "max_tokens": 128,
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
 
 ### 在 Claude Code 中使用
 
@@ -68,7 +96,6 @@ curl -X POST https://claude-worker-proxy.xxxx.workers.dev/gemini/https://generat
 
 claude
 ```
-
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "claude-worker-proxy",
             "version": "0.0.0",
             "license": "MIT",
+            "dependencies": {
+                "openai": "^6.45.0"
+            },
             "devDependencies": {
                 "prettier": "^3.6.2",
                 "typescript": "^5.5.2",
@@ -1286,12 +1289,52 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/miniflare/node_modules/zod": {
+            "version": "3.22.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+            "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
         "node_modules/ohash": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/openai": {
+            "version": "6.45.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+            "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+                "@smithy/hash-node": ">=4.3.0 <5",
+                "@smithy/signature-v4": ">=5.4.0 <6",
+                "ws": "^8.18.0",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-provider-node": {
+                    "optional": true
+                },
+                "@smithy/hash-node": {
+                    "optional": true
+                },
+                "@smithy/signature-v4": {
+                    "optional": true
+                },
+                "ws": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
@@ -1523,7 +1566,7 @@
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -1564,16 +1607,6 @@
             "dependencies": {
                 "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-            "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,7 @@
         "typescript": "^5.5.2",
         "wrangler": "^4.21.0"
     },
-    "dependencies": {}
+    "dependencies": {
+        "openai": "^6.45.0"
+    }
 }

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -39,10 +39,15 @@ export class impl implements provider.Provider {
     private convertToGeminiRequestBody(claudeRequest: types.ClaudeRequest): types.GeminiRequest {
         const toolUseMap = this.buildToolUseMap(claudeRequest.messages)
         const contents = this.convertMessages(claudeRequest.messages, toolUseMap)
+        const systemInstruction = this.convertSystemInstruction(claudeRequest.system)
 
         const geminiRequest: types.GeminiRequest = {
             model: claudeRequest.model,
             contents
+        }
+
+        if (systemInstruction) {
+            geminiRequest.systemInstruction = systemInstruction
         }
 
         if (claudeRequest.tools && claudeRequest.tools.length > 0) {
@@ -68,6 +73,22 @@ export class impl implements provider.Provider {
         }
 
         return geminiRequest
+    }
+
+    private convertSystemInstruction(system: types.ClaudeRequest['system']): types.GeminiContent | undefined {
+        if (!system) return undefined
+        const text =
+            typeof system === 'string'
+                ? system
+                : system
+                      .filter(part => part.type === 'text')
+                      .map(part => part.text)
+                      .join('\n')
+
+        if (!text) return undefined
+        return {
+            parts: [{ text }]
+        }
     }
 
     private buildToolUseMap(messages: types.ClaudeMessage[]): Map<string, string> {
@@ -203,6 +224,8 @@ export class impl implements provider.Provider {
     }
 
     private async convertStreamResponse(geminiResponse: Response): Promise<Response> {
+        let textBlockOpen = false
+
         return utils.processProviderStream(geminiResponse, (jsonStr, textBlockIndex, toolUseBlockIndex) => {
             const geminiData = JSON.parse(jsonStr) as types.GeminiResponse
             if (!geminiData.candidates || geminiData.candidates.length === 0) {
@@ -213,23 +236,47 @@ export class impl implements provider.Provider {
             const events: string[] = []
             let currentTextIndex = textBlockIndex
             let currentToolIndex = toolUseBlockIndex
+            let stopReason: types.ClaudeStopReason | undefined
 
             if (candidate.content) {
                 for (const part of candidate.content.parts) {
                     if ('text' in part && part.text) {
-                        events.push(...utils.processTextPart(part.text, currentTextIndex))
-                        currentTextIndex++
+                        if (!textBlockOpen) {
+                            events.push(utils.startTextBlock(currentTextIndex))
+                            textBlockOpen = true
+                        }
+                        events.push(utils.textDelta(part.text, currentTextIndex))
                     } else if ('functionCall' in part) {
-                        events.push(...utils.processToolUsePart(part.functionCall, currentToolIndex))
+                        if (textBlockOpen) {
+                            events.push(utils.stopContentBlock(currentTextIndex))
+                            currentTextIndex++
+                            textBlockOpen = false
+                        }
+                        events.push(
+                            ...utils.processToolUsePart(
+                                { name: part.functionCall.name, args: part.functionCall.args ?? {} },
+                                currentToolIndex
+                            )
+                        )
                         currentToolIndex++
                     }
                 }
             }
 
+            if (candidate.finishReason) {
+                if (textBlockOpen) {
+                    events.push(utils.stopContentBlock(currentTextIndex))
+                    currentTextIndex++
+                    textBlockOpen = false
+                }
+                stopReason = candidate.finishReason === 'MAX_TOKENS' ? 'max_tokens' : 'end_turn'
+            }
+
             return {
                 events,
                 textBlockIndex: currentTextIndex,
-                toolUseBlockIndex: currentToolIndex
+                toolUseBlockIndex: currentToolIndex,
+                stopReason
             }
         })
     }

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -175,7 +175,11 @@ export class impl implements provider.Provider {
             id: utils.generateId(),
             type: 'message',
             role: 'assistant',
-            content: []
+            content: [],
+            usage: {
+                input_tokens: 0,
+                output_tokens: 0
+            }
         }
 
         if (geminiData.candidates && geminiData.candidates.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,23 +38,29 @@ async function handle(request: Request): Promise<Response> {
             provider = new gemini.impl()
             break
         case 'openai':
-            provider = new openai.impl()
+            provider = new openai.ChatCompletionsProvider()
+            break
+        case 'openai-responses':
+        case 'responses':
+            provider = new openai.ResponsesProvider()
             break
         default:
             return new Response('Unsupported type', { status: 400 })
     }
 
-    const providerRequest = await provider.convertToProviderRequest(
-        new Request(request, { headers: mutatedHeaders }),
-        baseUrl,
-        apiKey
-    )
+    const inboundRequest = new Request(request, { headers: mutatedHeaders })
+    if (provider.handle) {
+        return await provider.handle(inboundRequest, baseUrl, apiKey)
+    }
+
+    const providerRequest = await provider.convertToProviderRequest(inboundRequest, baseUrl, apiKey)
     const providerResponse = await fetch(providerRequest)
     return await provider.convertToClaudeResponse(providerResponse)
 }
 
 function parsePath(url: URL): { typeParam?: string; baseUrl?: string; err?: Response } {
-    const pathParts = url.pathname.split('/').filter(part => part !== '')
+    const pathname = url.pathname.replace(/^\/+|\/+$/g, '')
+    const pathParts = pathname.split('/').filter(part => part !== '')
     if (pathParts.length < 3) {
         return {
             err: new Response('Invalid path format. Expected: /{type}/{provider_url}/v1/messages', { status: 400 })
@@ -66,14 +72,8 @@ function parsePath(url: URL): { typeParam?: string; baseUrl?: string; err?: Resp
     }
 
     const typeParam = pathParts[0]
-    const providerUrlParts = pathParts.slice(1, -2)
-
-    // [..., 'https:', ...] ==> [..., 'https:/', ...]
-    if (pathParts[1] && pathParts[1].startsWith('http')) {
-        pathParts[1] = pathParts[1] + '/'
-    }
-
-    const baseUrl = providerUrlParts.join('/')
+    const providerPath = pathParts.slice(1, -2).join('/')
+    const baseUrl = providerPath.replace(/^(https?):\/(?!\/)/, '$1://')
     if (!typeParam || !baseUrl) {
         return { err: new Response('Missing type or provider_url in path', { status: 400 }) }
     }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -24,6 +24,10 @@ type ClaudeStreamState = {
     textBlockIndex: number
     toolUseBlockIndex: number
     stopReason: types.ClaudeStopReason
+    usage: {
+        input_tokens: number
+        output_tokens: number
+    }
 }
 
 function createClient(apiKey: string, baseUrl: string): OpenAI {
@@ -83,7 +87,11 @@ function initStreamState(): ClaudeStreamState {
         textBlockOpen: false,
         textBlockIndex: 0,
         toolUseBlockIndex: 0,
-        stopReason: 'end_turn'
+        stopReason: 'end_turn',
+        usage: {
+            input_tokens: 0,
+            output_tokens: 0
+        }
     }
 }
 
@@ -126,7 +134,10 @@ export class ChatCompletionsProvider implements provider.Provider {
             if (claudeRequest.stream) {
                 const stream = await client.chat.completions.create({
                     ...openaiRequest,
-                    stream: true
+                    stream: true,
+                    stream_options: {
+                        include_usage: true
+                    }
                 } as ChatCompletionCreateParams)
                 return this.convertStreamResponse(stream as Stream<ChatCompletionChunk>)
             }
@@ -264,7 +275,11 @@ export class ChatCompletionsProvider implements provider.Provider {
             id: openaiData.id || utils.generateId(),
             type: 'message',
             role: 'assistant',
-            content: []
+            content: [],
+            usage: {
+                input_tokens: 0,
+                output_tokens: 0
+            }
         }
 
         if (openaiData.choices && openaiData.choices.length > 0) {
@@ -313,6 +328,13 @@ export class ChatCompletionsProvider implements provider.Provider {
 
                 try {
                     for await (const chunk of openaiStream) {
+                        if (chunk.usage) {
+                            state.usage = {
+                                input_tokens: chunk.usage.prompt_tokens,
+                                output_tokens: chunk.usage.completion_tokens
+                            }
+                        }
+
                         if (!chunk.choices || chunk.choices.length === 0) continue
 
                         const choice = chunk.choices[0]
@@ -365,7 +387,7 @@ export class ChatCompletionsProvider implements provider.Provider {
                     const events: string[] = []
                     closeTextBlockIfNeeded(events, state)
                     enqueueEvents(controller, events)
-                    utils.sendMessageDelta(controller, state.stopReason)
+                    utils.sendMessageDelta(controller, state.stopReason, state.usage)
                     utils.sendMessageStop(controller)
                     controller.close()
                 }
@@ -518,7 +540,11 @@ export class ResponsesProvider implements provider.Provider {
             type: 'message',
             role: 'assistant',
             content: [],
-            stop_reason: 'end_turn'
+            stop_reason: 'end_turn',
+            usage: {
+                input_tokens: 0,
+                output_tokens: 0
+            }
         }
 
         for (const output of openaiData.output ?? []) {
@@ -618,10 +644,22 @@ export class ResponsesProvider implements provider.Provider {
                             case 'response.completed':
                                 closeTextBlockIfNeeded(events, state)
                                 state.stopReason = stopReasonFromResponseStatus(event.response.status)
+                                if (event.response.usage) {
+                                    state.usage = {
+                                        input_tokens: event.response.usage.input_tokens ?? 0,
+                                        output_tokens: event.response.usage.output_tokens ?? 0
+                                    }
+                                }
                                 break
                             case 'response.incomplete':
                                 closeTextBlockIfNeeded(events, state)
                                 state.stopReason = 'max_tokens'
+                                if (event.response.usage) {
+                                    state.usage = {
+                                        input_tokens: event.response.usage.input_tokens ?? 0,
+                                        output_tokens: event.response.usage.output_tokens ?? 0
+                                    }
+                                }
                                 break
                         }
 
@@ -635,7 +673,7 @@ export class ResponsesProvider implements provider.Provider {
                     const events: string[] = []
                     closeTextBlockIfNeeded(events, state)
                     enqueueEvents(controller, events)
-                    utils.sendMessageDelta(controller, state.stopReason)
+                    utils.sendMessageDelta(controller, state.stopReason, state.usage)
                     utils.sendMessageStop(controller)
                     controller.close()
                 }

--- a/src/openai.ts
+++ b/src/openai.ts
@@ -1,16 +1,153 @@
+import OpenAI from 'openai'
+import type {
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionCreateParams,
+    ChatCompletionMessageParam
+} from 'openai/resources/chat/completions'
+import type {
+    FunctionTool,
+    Response as OpenAIResponse,
+    ResponseCreateParams,
+    ResponseFunctionToolCall,
+    ResponseInputItem,
+    ResponseOutputMessage,
+    ResponseStreamEvent
+} from 'openai/resources/responses/responses'
+import type { Stream } from 'openai/streaming'
 import * as types from './types'
 import * as provider from './provider'
 import * as utils from './utils'
 
-export class impl implements provider.Provider {
+type ClaudeStreamState = {
+    textBlockOpen: boolean
+    textBlockIndex: number
+    toolUseBlockIndex: number
+    stopReason: types.ClaudeStopReason
+}
+
+function createClient(apiKey: string, baseUrl: string): OpenAI {
+    return new OpenAI({
+        apiKey: apiKey.startsWith('Bearer ') ? apiKey.slice('Bearer '.length) : apiKey,
+        baseURL: baseUrl,
+        timeout: 600_000,
+        maxRetries: 0
+    })
+}
+
+function systemText(system: types.ClaudeRequest['system']): string | undefined {
+    if (!system) return undefined
+    if (typeof system === 'string') return system
+    return system
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n')
+}
+
+function contentToText(content: types.ClaudeContent): string {
+    if (typeof content === 'string') return content
+
+    return content
+        .filter(part => part.type === 'text')
+        .map(part => part.text)
+        .join('\n')
+}
+
+function toolResultToText(content: string | unknown): string {
+    return typeof content === 'string' ? content : JSON.stringify(content)
+}
+
+function stopReasonFromOpenAI(finishReason?: string | null): types.ClaudeStopReason {
+    switch (finishReason) {
+        case 'tool_calls':
+        case 'function_call':
+            return 'tool_use'
+        case 'length':
+            return 'max_tokens'
+        case 'stop':
+        default:
+            return 'end_turn'
+    }
+}
+
+function stopReasonFromResponseStatus(status?: string): types.ClaudeStopReason {
+    return status === 'incomplete' ? 'max_tokens' : 'end_turn'
+}
+
+function parseToolArguments(args: string): unknown {
+    return utils.safeJsonParse(args || '{}')
+}
+
+function initStreamState(): ClaudeStreamState {
+    return {
+        textBlockOpen: false,
+        textBlockIndex: 0,
+        toolUseBlockIndex: 0,
+        stopReason: 'end_turn'
+    }
+}
+
+function openTextBlockIfNeeded(events: string[], state: ClaudeStreamState): void {
+    if (state.textBlockOpen) return
+    events.push(utils.startTextBlock(state.textBlockIndex))
+    state.textBlockOpen = true
+}
+
+function closeTextBlockIfNeeded(events: string[], state: ClaudeStreamState): void {
+    if (!state.textBlockOpen) return
+    events.push(utils.stopContentBlock(state.textBlockIndex))
+    state.textBlockIndex++
+    state.textBlockOpen = false
+}
+
+function enqueueEvents(controller: ReadableStreamDefaultController, events: string[]): void {
+    for (const event of events) {
+        utils.enqueueRawSse(controller, event)
+    }
+}
+
+function errorToResponse(error: unknown): Response {
+    if (error instanceof OpenAI.APIError) {
+        const body = error.error ?? { error: { message: error.message, type: error.name } }
+        return jsonResponse(body, error.status ?? 500)
+    }
+
+    console.error(error)
+    return new Response('OpenAI SDK request failed', { status: 502 })
+}
+
+export class ChatCompletionsProvider implements provider.Provider {
+    async handle(request: Request, baseUrl: string, apiKey: string): Promise<Response> {
+        const claudeRequest = (await request.json()) as types.ClaudeRequest
+        const openaiRequest = this.convertToOpenAIRequestBody(claudeRequest)
+        const client = createClient(apiKey, baseUrl)
+
+        try {
+            if (claudeRequest.stream) {
+                const stream = await client.chat.completions.create({
+                    ...openaiRequest,
+                    stream: true
+                } as ChatCompletionCreateParams)
+                return this.convertStreamResponse(stream as Stream<ChatCompletionChunk>)
+            }
+
+            const completion = await client.chat.completions.create({
+                ...openaiRequest,
+                stream: false
+            } as ChatCompletionCreateParams)
+            return this.convertNormalResponse(completion as ChatCompletion)
+        } catch (error) {
+            return errorToResponse(error)
+        }
+    }
+
     async convertToProviderRequest(request: Request, baseUrl: string, apiKey: string): Promise<Request> {
         const claudeRequest = (await request.json()) as types.ClaudeRequest
         const openaiRequest = this.convertToOpenAIRequestBody(claudeRequest)
-
         const finalUrl = utils.buildUrl(baseUrl, 'chat/completions')
 
         const headers = new Headers(request.headers)
-        headers.set('Authorization', `Bearer ${apiKey}`)
+        headers.set('Authorization', apiKey.startsWith('Bearer ') ? apiKey : `Bearer ${apiKey}`)
         headers.set('Content-Type', 'application/json')
 
         return new Request(finalUrl, {
@@ -25,21 +162,15 @@ export class impl implements provider.Provider {
             return openaiResponse
         }
 
-        const contentType = openaiResponse.headers.get('content-type') || ''
-        const isStream = contentType.includes('text/event-stream')
-
-        if (isStream) {
-            return this.convertStreamResponse(openaiResponse)
-        } else {
-            return this.convertNormalResponse(openaiResponse)
-        }
+        const openaiData = (await openaiResponse.json()) as ChatCompletion
+        return this.convertNormalResponse(openaiData)
     }
 
-    private convertToOpenAIRequestBody(claudeRequest: types.ClaudeRequest): types.OpenAIRequest {
-        const openaiRequest: types.OpenAIRequest = {
+    private convertToOpenAIRequestBody(claudeRequest: types.ClaudeRequest): ChatCompletionCreateParams {
+        const openaiRequest: ChatCompletionCreateParams = {
             model: claudeRequest.model,
-            messages: this.convertMessages(claudeRequest.messages),
-            stream: claudeRequest.stream
+            messages: this.convertMessages(claudeRequest),
+            stream: claudeRequest.stream ?? false
         }
 
         if (claudeRequest.tools && claudeRequest.tools.length > 0) {
@@ -64,11 +195,14 @@ export class impl implements provider.Provider {
         return openaiRequest
     }
 
-    private convertMessages(claudeMessages: types.ClaudeMessage[]): types.OpenAIMessage[] {
-        const openaiMessages: types.OpenAIMessage[] = []
-        const toolCallMap = new Map<string, string>()
+    private convertMessages(claudeRequest: types.ClaudeRequest): ChatCompletionMessageParam[] {
+        const openaiMessages: ChatCompletionMessageParam[] = []
+        const system = systemText(claudeRequest.system)
+        if (system) {
+            openaiMessages.push({ role: 'system', content: system })
+        }
 
-        for (const message of claudeMessages) {
+        for (const message of claudeRequest.messages) {
             if (typeof message.content === 'string') {
                 openaiMessages.push({
                     role: message.role === 'assistant' ? 'assistant' : 'user',
@@ -78,7 +212,7 @@ export class impl implements provider.Provider {
             }
 
             const textContents: string[] = []
-            const toolCalls: types.OpenAIToolCall[] = []
+            const toolCalls: NonNullable<types.OpenAIMessage['tool_calls']> = []
             const toolResults: Array<{ tool_call_id: string; content: string }> = []
 
             for (const content of message.content) {
@@ -87,7 +221,6 @@ export class impl implements provider.Provider {
                         textContents.push(content.text)
                         break
                     case 'tool_use':
-                        toolCallMap.set(content.id, content.id)
                         toolCalls.push({
                             id: content.id,
                             type: 'function',
@@ -100,27 +233,18 @@ export class impl implements provider.Provider {
                     case 'tool_result':
                         toolResults.push({
                             tool_call_id: content.tool_use_id,
-                            content:
-                                typeof content.content === 'string' ? content.content : JSON.stringify(content.content)
+                            content: toolResultToText(content.content)
                         })
                         break
                 }
             }
 
             if (textContents.length > 0 || toolCalls.length > 0) {
-                const openaiMessage: types.OpenAIMessage = {
-                    role: message.role === 'assistant' ? 'assistant' : 'user'
-                }
-
-                if (textContents.length > 0) {
-                    openaiMessage.content = textContents.join('\n')
-                }
-
-                if (toolCalls.length > 0) {
-                    openaiMessage.tool_calls = toolCalls
-                }
-
-                openaiMessages.push(openaiMessage)
+                openaiMessages.push({
+                    role: message.role === 'assistant' ? 'assistant' : 'user',
+                    content: textContents.length > 0 ? textContents.join('\n') : null,
+                    tool_calls: toolCalls.length > 0 ? toolCalls : undefined
+                } as ChatCompletionMessageParam)
             }
 
             for (const toolResult of toolResults) {
@@ -135,11 +259,9 @@ export class impl implements provider.Provider {
         return openaiMessages
     }
 
-    private async convertNormalResponse(openaiResponse: Response): Promise<Response> {
-        const openaiData = (await openaiResponse.json()) as types.OpenAIResponse
-
+    private convertNormalResponse(openaiData: ChatCompletion): Response {
         const claudeResponse: types.ClaudeResponse = {
-            id: utils.generateId(),
+            id: openaiData.id || utils.generateId(),
             type: 'message',
             role: 'assistant',
             content: []
@@ -158,19 +280,17 @@ export class impl implements provider.Provider {
 
             if (message.tool_calls) {
                 for (const toolCall of message.tool_calls) {
+                    if (toolCall.type !== 'function') continue
                     claudeResponse.content.push({
                         type: 'tool_use',
                         id: toolCall.id,
                         name: toolCall.function.name,
-                        input: JSON.parse(toolCall.function.arguments)
+                        input: parseToolArguments(toolCall.function.arguments)
                     })
                 }
-                claudeResponse.stop_reason = 'tool_use'
-            } else if (choice.finish_reason === 'length') {
-                claudeResponse.stop_reason = 'max_tokens'
-            } else {
-                claudeResponse.stop_reason = 'end_turn'
             }
+
+            claudeResponse.stop_reason = stopReasonFromOpenAI(choice.finish_reason)
         }
 
         if (openaiData.usage) {
@@ -180,54 +300,370 @@ export class impl implements provider.Provider {
             }
         }
 
-        return new Response(JSON.stringify(claudeResponse), {
-            status: openaiResponse.status,
-            headers: {
-                'Content-Type': 'application/json'
-            }
-        })
+        return jsonResponse(claudeResponse, 200)
     }
 
-    private async convertStreamResponse(openaiResponse: Response): Promise<Response> {
-        return utils.processProviderStream(openaiResponse, (jsonStr, textBlockIndex, toolUseBlockIndex) => {
-            const openaiData = JSON.parse(jsonStr) as types.OpenAIStreamResponse
-            if (!openaiData.choices || openaiData.choices.length === 0) {
-                return null
-            }
+    private convertStreamResponse(openaiStream: Stream<ChatCompletionChunk>): Response {
+        const stream = new ReadableStream({
+            async start(controller) {
+                const state = initStreamState()
+                const toolCallState = new Map<number, { id?: string; name?: string; args: string }>()
 
-            const choice = openaiData.choices[0]
-            const delta = choice.delta
-            const events: string[] = []
-            let currentTextIndex = textBlockIndex
-            let currentToolIndex = toolUseBlockIndex
+                utils.sendMessageStart(controller)
 
-            if (delta.content) {
-                events.push(...utils.processTextPart(delta.content, currentTextIndex))
-                currentTextIndex++
-            }
+                try {
+                    for await (const chunk of openaiStream) {
+                        if (!chunk.choices || chunk.choices.length === 0) continue
 
-            if (delta.tool_calls) {
-                for (const toolCall of delta.tool_calls) {
-                    if (toolCall.function?.name && toolCall.function?.arguments) {
-                        events.push(
-                            ...utils.processToolUsePart(
-                                {
-                                    name: toolCall.function.name,
-                                    args: JSON.parse(toolCall.function.arguments)
-                                },
-                                currentToolIndex
-                            )
-                        )
-                        currentToolIndex++
+                        const choice = chunk.choices[0]
+                        const delta = choice.delta
+                        const events: string[] = []
+
+                        if (delta.content) {
+                            openTextBlockIfNeeded(events, state)
+                            events.push(utils.textDelta(delta.content, state.textBlockIndex))
+                        }
+
+                        if (delta.tool_calls) {
+                            for (const toolCall of delta.tool_calls) {
+                                const stateForTool = toolCallState.get(toolCall.index) ?? { args: '' }
+                                stateForTool.id = toolCall.id ?? stateForTool.id
+                                stateForTool.name = toolCall.function?.name ?? stateForTool.name
+                                stateForTool.args += toolCall.function?.arguments ?? ''
+                                toolCallState.set(toolCall.index, stateForTool)
+                            }
+                        }
+
+                        if (choice.finish_reason === 'tool_calls' || choice.finish_reason === 'function_call') {
+                            closeTextBlockIfNeeded(events, state)
+                            for (const [, toolCall] of [...toolCallState].sort(([a], [b]) => a - b)) {
+                                if (!toolCall.name) continue
+                                events.push(
+                                    ...utils.processToolUsePart(
+                                        {
+                                            name: toolCall.name,
+                                            args: parseToolArguments(toolCall.args)
+                                        },
+                                        state.toolUseBlockIndex
+                                    )
+                                )
+                                state.toolUseBlockIndex++
+                            }
+                            state.stopReason = 'tool_use'
+                        } else if (choice.finish_reason) {
+                            closeTextBlockIfNeeded(events, state)
+                            state.stopReason = stopReasonFromOpenAI(choice.finish_reason)
+                        }
+
+                        enqueueEvents(controller, events)
                     }
+                } catch (error) {
+                    console.error(error)
+                    controller.error(error)
+                    return
+                } finally {
+                    const events: string[] = []
+                    closeTextBlockIfNeeded(events, state)
+                    enqueueEvents(controller, events)
+                    utils.sendMessageDelta(controller, state.stopReason)
+                    utils.sendMessageStop(controller)
+                    controller.close()
                 }
             }
-
-            return {
-                events,
-                textBlockIndex: currentTextIndex,
-                toolUseBlockIndex: currentToolIndex
-            }
         })
+
+        return streamResponse(stream)
     }
 }
+
+export class ResponsesProvider implements provider.Provider {
+    async handle(request: Request, baseUrl: string, apiKey: string): Promise<Response> {
+        const claudeRequest = (await request.json()) as types.ClaudeRequest
+        const openaiRequest = this.convertToResponsesRequestBody(claudeRequest)
+        const client = createClient(apiKey, baseUrl)
+
+        try {
+            if (claudeRequest.stream) {
+                const stream = await client.responses.create({
+                    ...openaiRequest,
+                    stream: true
+                } as ResponseCreateParams)
+                return this.convertStreamResponse(stream as Stream<ResponseStreamEvent>)
+            }
+
+            const response = await client.responses.create({
+                ...openaiRequest,
+                stream: false
+            } as ResponseCreateParams)
+            return this.convertNormalResponse(response as OpenAIResponse)
+        } catch (error) {
+            return errorToResponse(error)
+        }
+    }
+
+    async convertToProviderRequest(request: Request, baseUrl: string, apiKey: string): Promise<Request> {
+        const claudeRequest = (await request.json()) as types.ClaudeRequest
+        const openaiRequest = this.convertToResponsesRequestBody(claudeRequest)
+        const finalUrl = utils.buildUrl(baseUrl, 'responses')
+
+        const headers = new Headers(request.headers)
+        headers.set('Authorization', apiKey.startsWith('Bearer ') ? apiKey : `Bearer ${apiKey}`)
+        headers.set('Content-Type', 'application/json')
+
+        return new Request(finalUrl, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(openaiRequest)
+        })
+    }
+
+    async convertToClaudeResponse(openaiResponse: Response): Promise<Response> {
+        if (!openaiResponse.ok) {
+            return openaiResponse
+        }
+
+        const openaiData = (await openaiResponse.json()) as OpenAIResponse
+        return this.convertNormalResponse(openaiData)
+    }
+
+    private convertToResponsesRequestBody(claudeRequest: types.ClaudeRequest): ResponseCreateParams {
+        const openaiRequest: ResponseCreateParams = {
+            model: claudeRequest.model,
+            input: this.convertInput(claudeRequest.messages),
+            stream: claudeRequest.stream ?? false
+        }
+
+        const system = systemText(claudeRequest.system)
+        if (system) {
+            openaiRequest.instructions = system
+        }
+
+        if (claudeRequest.tools && claudeRequest.tools.length > 0) {
+            openaiRequest.tools = claudeRequest.tools.map(tool => ({
+                type: 'function',
+                name: tool.name,
+                description: tool.description,
+                parameters: utils.cleanJsonSchema(tool.input_schema),
+                strict: null
+            })) as FunctionTool[]
+        }
+
+        if (claudeRequest.temperature !== undefined) {
+            openaiRequest.temperature = claudeRequest.temperature
+        }
+
+        if (claudeRequest.max_tokens !== undefined) {
+            openaiRequest.max_output_tokens = claudeRequest.max_tokens
+        }
+
+        return openaiRequest
+    }
+
+    private convertInput(messages: types.ClaudeMessage[]): ResponseInputItem[] {
+        const input: ResponseInputItem[] = []
+
+        for (const message of messages) {
+            if (typeof message.content === 'string') {
+                input.push({
+                    type: 'message',
+                    role: message.role,
+                    content: [
+                        {
+                            type: message.role === 'assistant' ? 'output_text' : 'input_text',
+                            text: message.content
+                        }
+                    ]
+                } as ResponseInputItem)
+                continue
+            }
+
+            const text = contentToText(message.content)
+            if (text) {
+                input.push({
+                    type: 'message',
+                    role: message.role,
+                    content: [
+                        {
+                            type: message.role === 'assistant' ? 'output_text' : 'input_text',
+                            text
+                        }
+                    ]
+                } as ResponseInputItem)
+            }
+
+            for (const content of message.content) {
+                if (content.type === 'tool_use') {
+                    input.push({
+                        type: 'function_call',
+                        call_id: content.id,
+                        name: content.name,
+                        arguments: JSON.stringify(content.input)
+                    } as ResponseInputItem)
+                } else if (content.type === 'tool_result') {
+                    input.push({
+                        type: 'function_call_output',
+                        call_id: content.tool_use_id,
+                        output: toolResultToText(content.content)
+                    } as ResponseInputItem)
+                }
+            }
+        }
+
+        return input
+    }
+
+    private convertNormalResponse(openaiData: OpenAIResponse): Response {
+        const claudeResponse: types.ClaudeResponse = {
+            id: openaiData.id || utils.generateId(),
+            type: 'message',
+            role: 'assistant',
+            content: [],
+            stop_reason: 'end_turn'
+        }
+
+        for (const output of openaiData.output ?? []) {
+            if (output.type === 'message') {
+                const message = output as ResponseOutputMessage
+                for (const content of message.content ?? []) {
+                    if (content.type === 'output_text') {
+                        claudeResponse.content.push({ type: 'text', text: content.text })
+                    }
+                }
+            } else if (output.type === 'function_call') {
+                const toolCall = output as ResponseFunctionToolCall
+                claudeResponse.content.push({
+                    type: 'tool_use',
+                    id: toolCall.call_id,
+                    name: toolCall.name,
+                    input: parseToolArguments(toolCall.arguments)
+                })
+                claudeResponse.stop_reason = 'tool_use'
+            }
+        }
+
+        if (claudeResponse.content.length === 0 && openaiData.output_text) {
+            claudeResponse.content.push({ type: 'text', text: openaiData.output_text })
+        }
+
+        if (openaiData.status === 'incomplete') {
+            claudeResponse.stop_reason = 'max_tokens'
+        }
+
+        if (openaiData.usage) {
+            claudeResponse.usage = {
+                input_tokens: openaiData.usage.input_tokens ?? 0,
+                output_tokens: openaiData.usage.output_tokens ?? 0
+            }
+        }
+
+        return jsonResponse(claudeResponse, 200)
+    }
+
+    private convertStreamResponse(openaiStream: Stream<ResponseStreamEvent>): Response {
+        const stream = new ReadableStream({
+            async start(controller) {
+                const state = initStreamState()
+                const functionCalls = new Map<number, { name?: string; callId?: string; args: string }>()
+
+                utils.sendMessageStart(controller)
+
+                try {
+                    for await (const event of openaiStream) {
+                        const events: string[] = []
+
+                        switch (event.type) {
+                            case 'response.output_text.delta':
+                                if (event.delta) {
+                                    openTextBlockIfNeeded(events, state)
+                                    events.push(utils.textDelta(event.delta, state.textBlockIndex))
+                                }
+                                break
+                            case 'response.output_item.added':
+                                if (event.item?.type === 'function_call') {
+                                    const item = event.item as ResponseFunctionToolCall
+                                    const index = event.output_index ?? functionCalls.size
+                                    functionCalls.set(index, {
+                                        name: item.name,
+                                        callId: item.call_id,
+                                        args: item.arguments ?? ''
+                                    })
+                                }
+                                break
+                            case 'response.function_call_arguments.delta': {
+                                const call = functionCalls.get(event.output_index) ?? { args: '' }
+                                call.args += event.delta ?? ''
+                                functionCalls.set(event.output_index, call)
+                                break
+                            }
+                            case 'response.output_item.done':
+                                if (event.item?.type === 'function_call') {
+                                    closeTextBlockIfNeeded(events, state)
+                                    const item = event.item as ResponseFunctionToolCall
+                                    const call = functionCalls.get(event.output_index) ?? { args: '' }
+                                    call.name = item.name ?? call.name
+                                    call.callId = item.call_id ?? call.callId
+                                    call.args = item.arguments ?? call.args
+                                    if (call.name) {
+                                        events.push(
+                                            ...utils.processToolUsePart(
+                                                { name: call.name, args: parseToolArguments(call.args) },
+                                                state.toolUseBlockIndex
+                                            )
+                                        )
+                                        state.toolUseBlockIndex++
+                                        state.stopReason = 'tool_use'
+                                    }
+                                }
+                                break
+                            case 'response.completed':
+                                closeTextBlockIfNeeded(events, state)
+                                state.stopReason = stopReasonFromResponseStatus(event.response.status)
+                                break
+                            case 'response.incomplete':
+                                closeTextBlockIfNeeded(events, state)
+                                state.stopReason = 'max_tokens'
+                                break
+                        }
+
+                        enqueueEvents(controller, events)
+                    }
+                } catch (error) {
+                    console.error(error)
+                    controller.error(error)
+                    return
+                } finally {
+                    const events: string[] = []
+                    closeTextBlockIfNeeded(events, state)
+                    enqueueEvents(controller, events)
+                    utils.sendMessageDelta(controller, state.stopReason)
+                    utils.sendMessageStop(controller)
+                    controller.close()
+                }
+            }
+        })
+
+        return streamResponse(stream)
+    }
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+}
+
+function streamResponse(stream: ReadableStream): Response {
+    return new Response(stream, {
+        status: 200,
+        headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache',
+            Connection: 'keep-alive'
+        }
+    })
+}
+
+export { ChatCompletionsProvider as impl }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,5 @@
 export interface Provider {
+    handle?(request: Request, baseUrl: string, apiKey: string): Promise<Response>
     convertToProviderRequest(request: Request, baseUrl: string, apiKey: string): Promise<Request>
     convertToClaudeResponse(providerResponse: Response): Promise<Response>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,13 @@
 export interface JsonSchema {
-    type?: 'object' | 'string' | 'number' | 'boolean' | 'array'
+    type?: 'object' | 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'null'
     properties?: { [key: string]: JsonSchema }
     required?: string[]
     description?: string
     items?: JsonSchema
+    enum?: Array<string | number | boolean | null>
+    anyOf?: JsonSchema[]
+    oneOf?: JsonSchema[]
+    additionalProperties?: boolean | JsonSchema
 }
 
 export interface ClaudeTool {
@@ -28,6 +32,7 @@ export interface ClaudeMessage {
 export interface ClaudeRequest {
     model: string
     messages: ClaudeMessage[]
+    system?: string | Array<{ type: 'text'; text: string }>
     max_tokens?: number
     temperature?: number
     stream?: boolean
@@ -39,12 +44,14 @@ export interface ClaudeResponse {
     type: 'message'
     role: 'assistant'
     content: Array<{ type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: any }>
-    stop_reason?: 'end_turn' | 'tool_use' | 'max_tokens'
+    stop_reason?: ClaudeStopReason
     usage?: {
         input_tokens: number
         output_tokens: number
     }
 }
+
+export type ClaudeStopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'stop_sequence'
 
 export interface GeminiFunctionDeclaration {
     name: string
@@ -69,6 +76,7 @@ export interface GeminiContent {
 export interface GeminiRequest {
     model?: string
     contents: GeminiContent[]
+    systemInstruction?: GeminiContent
     tools?: GeminiTool[]
     generationConfig?: {
         temperature?: number
@@ -153,6 +161,64 @@ export interface OpenAIRequest {
     temperature?: number
     max_tokens?: number
     stream?: boolean
+}
+
+export interface OpenAIResponsesRequest {
+    model: string
+    input: OpenAIResponsesInputItem[]
+    instructions?: string
+    tools?: OpenAIResponsesTool[]
+    temperature?: number
+    max_output_tokens?: number
+    stream?: boolean
+}
+
+export type OpenAIResponsesInputItem =
+    | {
+          type: 'message'
+          role: 'user' | 'assistant' | 'system'
+          content: Array<{ type: 'input_text'; text: string } | { type: 'output_text'; text: string }>
+      }
+    | {
+          type: 'function_call'
+          call_id: string
+          name: string
+          arguments: string
+      }
+    | {
+          type: 'function_call_output'
+          call_id: string
+          output: string
+      }
+
+export interface OpenAIResponsesTool {
+    type: 'function'
+    name: string
+    description?: string
+    parameters?: any
+}
+
+export interface OpenAIResponsesResponse {
+    id: string
+    output?: Array<
+        | {
+              type: 'message'
+              content?: Array<{ type: 'output_text'; text: string } | { type: string; [key: string]: any }>
+          }
+        | {
+              type: 'function_call'
+              call_id: string
+              name: string
+              arguments: string
+          }
+        | { type: string; [key: string]: any }
+    >
+    output_text?: string
+    status?: string
+    usage?: {
+        input_tokens?: number
+        output_tokens?: number
+    }
 }
 
 export interface OpenAIChoice {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface ClaudeResponse {
     role: 'assistant'
     content: Array<{ type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: any }>
     stop_reason?: ClaudeStopReason
-    usage?: {
+    usage: {
         input_tokens: number
         output_tokens: number
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,26 +24,35 @@ export function enqueueRawSse(controller: ReadableStreamDefaultController, event
     controller.enqueue(encoder.encode(event))
 }
 
-export function sendMessageStart(controller: ReadableStreamDefaultController): void {
+export function sendMessageStart(
+    controller: ReadableStreamDefaultController,
+    usage: { input_tokens: number; output_tokens: number } = { input_tokens: 0, output_tokens: 0 }
+): void {
     const event = sse('message_start', {
         type: 'message_start',
         message: {
             id: generateId(),
             type: 'message',
             role: 'assistant',
-            content: []
+            content: [],
+            usage
         }
     })
     controller.enqueue(encoder.encode(event))
 }
 
-export function sendMessageDelta(controller: ReadableStreamDefaultController, stopReason: string): void {
+export function sendMessageDelta(
+    controller: ReadableStreamDefaultController,
+    stopReason: string,
+    usage: { input_tokens: number; output_tokens: number } = { input_tokens: 0, output_tokens: 0 }
+): void {
     enqueueSse(controller, 'message_delta', {
         type: 'message_delta',
         delta: {
             stop_reason: stopReason,
             stop_sequence: null
-        }
+        },
+        usage
     })
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,31 @@
 export function generateId(): string {
-    return Math.random().toString(36).substring(2)
+    return crypto.randomUUID()
+}
+
+const encoder = new TextEncoder()
+
+export function safeJsonParse(value: string): any {
+    try {
+        return JSON.parse(value)
+    } catch {
+        return {}
+    }
+}
+
+export function sse(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`
+}
+
+export function enqueueSse(controller: ReadableStreamDefaultController, event: string, data: unknown): void {
+    controller.enqueue(encoder.encode(sse(event, data)))
+}
+
+export function enqueueRawSse(controller: ReadableStreamDefaultController, event: string): void {
+    controller.enqueue(encoder.encode(event))
 }
 
 export function sendMessageStart(controller: ReadableStreamDefaultController): void {
-    const event = `event: message_start\ndata: ${JSON.stringify({
+    const event = sse('message_start', {
         type: 'message_start',
         message: {
             id: generateId(),
@@ -11,48 +33,62 @@ export function sendMessageStart(controller: ReadableStreamDefaultController): v
             role: 'assistant',
             content: []
         }
-    })}\n\n`
-    controller.enqueue(new TextEncoder().encode(event))
+    })
+    controller.enqueue(encoder.encode(event))
+}
+
+export function sendMessageDelta(controller: ReadableStreamDefaultController, stopReason: string): void {
+    enqueueSse(controller, 'message_delta', {
+        type: 'message_delta',
+        delta: {
+            stop_reason: stopReason,
+            stop_sequence: null
+        }
+    })
 }
 
 export function sendMessageStop(controller: ReadableStreamDefaultController): void {
-    const event = `event: message_stop\ndata: ${JSON.stringify({
+    const event = sse('message_stop', {
         type: 'message_stop'
-    })}\n\n`
-    controller.enqueue(new TextEncoder().encode(event))
+    })
+    controller.enqueue(encoder.encode(event))
+}
+
+export function startTextBlock(index: number): string {
+    return sse('content_block_start', {
+        type: 'content_block_start',
+        index,
+        content_block: {
+            type: 'text',
+            text: ''
+        }
+    })
+}
+
+export function textDelta(text: string, index: number): string {
+    return sse('content_block_delta', {
+        type: 'content_block_delta',
+        index,
+        delta: {
+            type: 'text_delta',
+            text
+        }
+    })
+}
+
+export function stopContentBlock(index: number): string {
+    return sse('content_block_stop', {
+        type: 'content_block_stop',
+        index
+    })
 }
 
 export function processTextPart(text: string, index: number): string[] {
     const events: string[] = []
 
-    events.push(
-        `event: content_block_start\ndata: ${JSON.stringify({
-            type: 'content_block_start',
-            index,
-            content_block: {
-                type: 'text',
-                text: ''
-            }
-        })}\n\n`
-    )
-
-    events.push(
-        `event: content_block_delta\ndata: ${JSON.stringify({
-            type: 'content_block_delta',
-            index,
-            delta: {
-                type: 'text_delta',
-                text
-            }
-        })}\n\n`
-    )
-
-    events.push(
-        `event: content_block_stop\ndata: ${JSON.stringify({
-            type: 'content_block_stop',
-            index
-        })}\n\n`
-    )
+    events.push(startTextBlock(index))
+    events.push(textDelta(text, index))
+    events.push(stopContentBlock(index))
 
     return events
 }
@@ -62,7 +98,7 @@ export function processToolUsePart(functionCall: { name: string; args: any }, in
     const toolUseId = generateId()
 
     events.push(
-        `event: content_block_start\ndata: ${JSON.stringify({
+        sse('content_block_start', {
             type: 'content_block_start',
             index,
             content_block: {
@@ -71,26 +107,21 @@ export function processToolUsePart(functionCall: { name: string; args: any }, in
                 name: functionCall.name,
                 input: {}
             }
-        })}\n\n`
+        })
     )
 
     events.push(
-        `event: content_block_delta\ndata: ${JSON.stringify({
+        sse('content_block_delta', {
             type: 'content_block_delta',
             index,
             delta: {
                 type: 'input_json_delta',
                 partial_json: JSON.stringify(functionCall.args)
             }
-        })}\n\n`
+        })
     )
 
-    events.push(
-        `event: content_block_stop\ndata: ${JSON.stringify({
-            type: 'content_block_stop',
-            index
-        })}\n\n`
-    )
+    events.push(stopContentBlock(index))
 
     return events
 }
@@ -109,7 +140,7 @@ export async function processProviderStream(
         jsonStr: string,
         textIndex: number,
         toolIndex: number
-    ) => { events: string[]; textBlockIndex: number; toolUseBlockIndex: number } | null
+    ) => { events: string[]; textBlockIndex: number; toolUseBlockIndex: number; stopReason?: string } | null
 ): Promise<Response> {
     const stream = new ReadableStream({
         async start(controller) {
@@ -123,6 +154,7 @@ export async function processProviderStream(
             let buffer = ''
             let textBlockIndex = 0
             let toolUseBlockIndex = 0
+            let stopReason = 'end_turn'
 
             sendMessageStart(controller)
 
@@ -146,23 +178,26 @@ export async function processProviderStream(
                         if (result) {
                             textBlockIndex = result.textBlockIndex
                             toolUseBlockIndex = result.toolUseBlockIndex
+                            stopReason = result.stopReason ?? stopReason
 
                             for (const event of result.events) {
-                                controller.enqueue(new TextEncoder().encode(event))
+                                controller.enqueue(encoder.encode(event))
                             }
                         }
                     }
                 }
             } finally {
-                if (buffer.trim()) {
+                if (buffer.trim() && buffer.startsWith('data: ')) {
                     const result = processLine(buffer.slice(6), textBlockIndex, toolUseBlockIndex)
                     if (result) {
+                        stopReason = result.stopReason ?? stopReason
                         for (const event of result.events) {
-                            controller.enqueue(new TextEncoder().encode(event))
+                            controller.enqueue(encoder.encode(event))
                         }
                     }
                 }
                 reader.releaseLock()
+                sendMessageDelta(controller, stopReason)
                 sendMessageStop(controller)
                 controller.close()
             }


### PR DESCRIPTION
  ## Summary

  - Use the official OpenAI JavaScript SDK for OpenAI provider requests.
  - Add OpenAI Responses API support via `/openai-responses/.../v1/messages`.
  - Preserve Claude-compatible request/response conversion for Claude Code.
  - Fix streaming text block handling so token deltas append to one Claude content block instead of creating many short blocks.
  - Always include Claude `usage.input_tokens` and `usage.output_tokens` in responses and stream events to avoid Claude Code crashes.
  - Add Gemini system prompt support and align Gemini streaming block handling.